### PR TITLE
Update default CSH IdP issuer URL

### DIFF
--- a/config.env.py
+++ b/config.env.py
@@ -14,7 +14,7 @@ LDAP_BIND_PW=os.environ.get('MAP_LDAP_BIND_PW', '')
 LDAP_USER_OU=os.environ.get('MAP_LDAP_USER_OU', 'ou=Users,dc=csh,dc=rit,dc=edu')
 
 # OpenID Connect SSO config
-OIDC_ISSUER = os.environ.get('MAP_OIDC_ISSUER', 'https://sso.csh.rit.edu/auth/realms/csh')
+OIDC_ISSUER = os.environ.get('MAP_OIDC_ISSUER', 'https://sso.csh.rit.edu/realms/csh')
 OIDC_CLIENT_CONFIG = {
     'client_id': os.environ.get('MAP_OIDC_CLIENT_ID', 'map'),
     'client_secret': os.environ.get('MAP_OIDC_CLIENT_SECRET', ''),

--- a/config.sample.py
+++ b/config.sample.py
@@ -12,7 +12,7 @@ LDAP_BIND_PW = 'lolno'
 LDAP_USER_OU = 'ou=Users,dc=csh,dc=rit,dc=edu'
 
 # OpenID Connect SSO config
-OIDC_ISSUER = 'https://sso.csh.rit.edu/auth/realms/csh'
+OIDC_ISSUER = 'https://sso.csh.rit.edu/realms/csh'
 OIDC_CLIENT_CONFIG = {
     'client_id': 'map',
     'client_secret': 'lolno',


### PR DESCRIPTION
Keycloak has been migrated to OpenShift, and the base URL for the endpoints have changed. This PR updates the URL(s) in your project for the new deployment.