### PR TITLE
Fix svg viewbox for mobile users

### DIFF
--- a/csh_map/templates/index.html
+++ b/csh_map/templates/index.html
@@ -77,7 +77,7 @@
         </div>
         <div class="row">
             <div class="col-md-12 col-lg-8 col-lg-offset-2" id="map-container">
-                <svg id="floorplan" xmlns="http://www.w3.org/2000/svg" viewBox="1464 -458 2772.3 2100">
+                <svg id="floorplan" xmlns="http://www.w3.org/2000/svg" viewBox="1464 -458 2772.3 2500">
                     <g id="southSide">
                         <path id="nrh-3-3121" class="room bathroom" data-toggle="modal" data-target="#map-modal" d="M1620.3 400v111h93v-145h-36v34z" />
                         <path id="nrh-3-3111" class="room" data-toggle="modal" data-target="#map-modal" d="M1850.3 292h119v219h-119z" />


### PR DESCRIPTION
The svg viewbox was overlapping with other elements when viewed on mobile